### PR TITLE
$wgThumbnailNamespaces

### DIFF
--- a/mediawiki/per-wiki/central/settings.php
+++ b/mediawiki/per-wiki/central/settings.php
@@ -12,6 +12,15 @@ $wgLogos = [
   'icon' => "/resources/per-wiki/$wmgWiki/logos/logo-2x.png"
 ];
 
+//< Files and file uploads >
+
+//<< Images >>
+
+//<<< Thumbnail settings >>>
+
+// 1.40+
+$wgThumbnailNamespaces = [NS_FILE, NS_HELP, NS_MAIN, NS_PROJECT, NS_USER];
+
 //< ResourceLoader >
 
 $wgAllowSiteCSSOnRestrictedPages = true;


### PR DESCRIPTION
`$wgThumbnailNamespaces` was introduced in MediaWiki 1.40-wmf.4. Let's try this new setting on `central` for now.
This pull request makes Special:Search show thumbnails on `central` for search results for pages in File, Help, Main, Project and User namespaces.