### PR TITLE
Remove purge permission

### DIFF
--- a/mediawiki/global-settings.php
+++ b/mediawiki/global-settings.php
@@ -539,7 +539,6 @@ $wgGroupPermissions = [
     'move' => true,
     'move-rootuserpages' => true,
     'movefile' => true,
-    'purge' => true,
     'reupload' => true,
     'sendemail' => true,
     'upload' => true


### PR DESCRIPTION
`purge` permission has been [removed in MediaWiki 1.41](https://gerrit.wikimedia.org/r/c/mediawiki/core/+/964878) and it did not do anything in old versions.